### PR TITLE
Removes debug stations from rotation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -40,11 +40,5 @@ map snaxi
 	minplayers 25
 endmap
 
-map runtimestation
-endmap
-
-map multiz_debug
-endmap
-
 map kilostation
 endmap


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes "RuntimeStation" and "Multi-Z debug" from rotation. For obvious reasons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People keep voting for these stations, even though they should be out of rotation

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: Removed debug stations from rotation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
